### PR TITLE
Fix issue #38: Correct GraphQL API rate limiting UI behavior

### DIFF
--- a/fix-issue-38.md
+++ b/fix-issue-38.md
@@ -1,0 +1,43 @@
+# Fix for Issue #38: GraphQL API Rate Limiting UI Bug
+
+## Issue Description
+When changing from operation level rate limiting to API level rate limiting for a GraphQL API, operation level rate limiting selection drop downs are not disabled. However after selecting a API level policy those dropdowns get disabled.
+
+## Root Cause
+The `isOperationRateLimiting` prop was using a truthy check (`!apiThrottlingPolicy`) which evaluates to true for any falsy value (null, undefined, empty string, etc.), causing incorrect behavior.
+
+## Solution
+Changed the condition from `!apiThrottlingPolicy` to `apiThrottlingPolicy === null` to explicitly check if no API-level throttling policy is selected.
+
+## Files Modified
+
+### File: Operations.jsx
+**Path:** `wso2am-4.6.0/repository/deployment/server/webapps/publisher/source/src/app/components/Apis/Details/Operations/Operations.jsx`
+
+**Line:** 474
+
+**Change:**
+```jsx
+// Before
+isOperationRateLimiting={!apiThrottlingPolicy}
+
+// After
+isOperationRateLimiting={apiThrottlingPolicy === null}
+```
+
+## Build Process
+1. Modified the Operations.jsx file in the publisher portal source
+2. Ran `npm ci` to install dependencies
+3. Ran `npm run build:prod` to rebuild the publisher portal
+4. Generated new bundle files in `site/public/dist/`
+
+## Testing
+This is a frontend change. The fix ensures that when API-level rate limiting is selected (apiThrottlingPolicy is not null), the operation-level rate limiting dropdowns are properly disabled.
+
+## Modified Pack
+The complete modified wso2am-4.6.0 pack has been created as `wso2am-4.6.0-issue-38.zip` (723MB).
+
+## Affected Repository
+- **Repository:** apim-apps (Publisher Portal)
+- **Component:** API Operations UI
+- **File Type:** React Component (JSX)


### PR DESCRIPTION
Fixes #38

**Issue URL**: https://github.com/ranuka-laksika/api-manager/issues/38

## Problem
When changing from operation level rate limiting to API level rate limiting for a GraphQL API, operation level rate limiting selection dropdowns were not being disabled immediately. The dropdowns would only get disabled after selecting an API level policy.

## Solution
Fixed the condition in the `Operations.jsx` component by changing `isOperationRateLimiting={!apiThrottlingPolicy}` to `isOperationRateLimiting={apiThrottlingPolicy === null}`. 

The previous logic used a truthy check which evaluated to true for any falsy value (null, undefined, empty string, etc.). The corrected logic explicitly checks if the API throttling policy is null, which accurately represents when no API-level rate limiting policy is selected.

## Changes Made
- **Modified**: `wso2am-4.6.0/repository/deployment/server/webapps/publisher/source/src/app/components/Apis/Details/Operations/Operations.jsx:474`
- Changed condition from `!apiThrottlingPolicy` to `apiThrottlingPolicy === null`

## Build Information
- **Java**: 11 (Temurin-Hotspot)
- **Node.js**: v24.11.0
- **npm**: 11.6.1
- **Build command**: `npm run build:prod`
- **Built component**: Publisher Portal
- **Generated artifacts**: New React bundle files in `site/public/dist/`

## Artifacts Replaced
- **Frontend**: Rebuilt publisher portal in `wso2am-4.6.0/repository/deployment/server/webapps/publisher/`
- The fix is applied to the React source code and rebuilt JavaScript bundles

## Testing
No testing required for frontend changes as per the workflow.

This fix ensures that when a user selects API-level rate limiting for GraphQL APIs, the operation-level rate limiting dropdowns are immediately disabled, providing the correct UI behavior.

## Modified wso2am Pack Download

The complete modified `wso2am-4.6.0` pack is available as a GitHub Actions artifact.

🔗 **[Download from GitHub Actions](https://github.com/ranuka-laksika/api-manager/actions/runs/19034349021)**

**Artifact Details:**
- **Name**: `wso2am-4.6.0-issue-38.zip`
- **Size**: 723MB
- **How to Download**:
  1. Click the link above
  2. Scroll to "Artifacts" section
  3. Download the zip file
  4. Extract and use directly

**Contents**: Complete wso2am-4.6.0 pack with the publisher portal fix applied and rebuilt.