### PR TITLE
Fix issue #69: Add templated configuration support to XML Validator policy

### DIFF
--- a/wso2am-4.6.0/repository/resources/operation_policies/definitions/xmlValidator_v1.j2
+++ b/wso2am-4.6.0/repository/resources/operation_policies/definitions/xmlValidator_v1.j2
@@ -1,0 +1,26 @@
+<log level="custom">
+    <property name="IN_MESSAGE" value="xml_validator"/>
+</log>
+<property name="xmlValidation" value="true"/>
+<property name="dtdEnabled" value="{{dtdEnabled}}"/>
+<property name="externalEntitiesEnabled" value="{{externalEntitiesEnabled}}"/>
+<property name="maxXMLDepth" value="{{maxXMLDepth}}"/>
+<property name="maxElementCount" value="{{maxElementCount}}"/>
+<property name="maxAttributeCount" value="{{maxAttributeCount}}"/>
+<property name="maxAttributeLength" value="{{maxAttributeLength}}"/>
+<property name="maxChildrenPerElement" value="{{maxChildrenPerElement}}"/>
+<property name="entityExpansionLimit" value="{{entityExpansionLimit}}"/>
+<property name="schemaValidation" value="false"/>
+<switch source="get-property('To')">
+        <!--<case regex=".*/addResource.*">-->
+            <!--<property name="xsdURL" value="<insert XSD_URL>"/>-->
+        <!--</case>-->
+        <!--<case regex=".*/update.*">-->
+            <!--<property name="xsdURL" value="<insert XSD_URL>"/>-->
+        <!--</case>-->
+        <!--<case regex=".*/delete.*">-->
+            <!--<property name="xsdURL" value="<insert XSD_URL>d"/>-->
+        <!--</case>-->
+</switch>
+<property name="RequestMessageBufferSize" value="{{requestMessageBufferSize}}"/>
+<class name="{{xmlSchemaValidator}}"/>

--- a/wso2am-4.6.0/repository/resources/operation_policies/specifications/xmlValidator_v1.json
+++ b/wso2am-4.6.0/repository/resources/operation_policies/specifications/xmlValidator_v1.json
@@ -1,0 +1,108 @@
+{
+  "category": "Mediation",
+  "name": "xmlValidator",
+  "version": "v1",
+  "displayName": "XML Validator",
+  "description": "This policy validates the request body of the XML message",
+  "applicableFlows": [
+    "request"
+  ],
+  "supportedGateways": [
+    "Synapse"
+  ],
+  "supportedApiTypes": [
+    "HTTP"
+  ],
+  "policyAttributes": [
+    {
+      "name": "dtdEnabled",
+      "displayName": "DTD Enabled",
+      "description": "Enable or disable Document Type Definition (DTD) processing",
+      "validationRegex": "^(true|false)$",
+      "type": "Boolean",
+      "defaultValue": false,
+      "required": false
+    },
+    {
+      "name": "externalEntitiesEnabled",
+      "displayName": "External Entities Enabled",
+      "description": "Enable or disable external entity processing",
+      "validationRegex": "^(true|false)$",
+      "type": "Boolean",
+      "defaultValue": true,
+      "required": false
+    },
+    {
+      "name": "maxXMLDepth",
+      "displayName": "Max XML Depth",
+      "description": "Maximum depth of the XML structure allowed",
+      "validationRegex": "^\\d{1,3}$",
+      "type": "Integer",
+      "defaultValue": 100,
+      "required": false
+    },
+    {
+      "name": "maxElementCount",
+      "displayName": "Max Element Count",
+      "description": "Maximum number of elements allowed in the XML payload",
+      "validationRegex": "^\\d{1,3}$",
+      "type": "Integer",
+      "defaultValue": 100,
+      "required": false
+    },
+    {
+      "name": "maxAttributeCount",
+      "displayName": "Max Attribute Count",
+      "description": "Maximum number of attributes allowed per element",
+      "validationRegex": "^\\d{1,3}$",
+      "type": "Integer",
+      "defaultValue": 100,
+      "required": false
+    },
+    {
+      "name": "maxAttributeLength",
+      "displayName": "Max Attribute Length",
+      "description": "Maximum length of an attribute value",
+      "validationRegex": "^\\d{1,3}$",
+      "type": "Integer",
+      "defaultValue": 100,
+      "required": false
+    },
+    {
+      "name": "maxChildrenPerElement",
+      "displayName": "Max Children Per Element",
+      "description": "Maximum number of child elements allowed per element",
+      "validationRegex": "^\\d{1,3}$",
+      "type": "Integer",
+      "defaultValue": 100,
+      "required": false
+    },
+    {
+      "name": "entityExpansionLimit",
+      "displayName": "Entity Expansion Limit",
+      "description": "Maximum number of entity expansions allowed",
+      "validationRegex": "^\\d{1,3}$",
+      "type": "Integer",
+      "defaultValue": 100,
+      "required": false
+    },
+    {
+      "name": "requestMessageBufferSize",
+      "displayName": "Request Message Buffer Size",
+      "description": "Request message buffer size",
+      "validationRegex": "^\\d{1,4}$",
+      "type": "Integer",
+      "defaultValue": 1024,
+      "required": false
+    },
+    {
+      "name": "xmlSchemaValidator",
+      "displayName": "XML Schema Validator",
+      "description": "XML schema validator implementation class",
+      "validationRegex": "^([a-zA-Z_$][a-zA-Z\\d_$.]*)$",
+      "type": "String",
+      "defaultValue": "org.wso2.carbon.apimgt.gateway.mediators.XMLSchemaValidator",
+      "required": false
+    }
+  ]
+}


### PR DESCRIPTION
Fixes #69

**Issue URL**: https://github.com/ranuka-laksika/api-manager/issues/69

## Problem

In WSO2 API Manager v4.6.0, the XML validator policy has hardcoded configuration values, unlike the JSON validator which supports templated parameters that can be modified through the Publisher UI. This limitation forced users to manually download, edit, and re-upload the XML validator policy as a custom policy just to adjust configuration limits.

## Solution

Introduced templated configuration parameters in the XML validator policy, bringing it to feature parity with the JSON validator policy. Users can now modify XML validation parameters directly through the Publisher UI when applying the policy to an API resource.

## Changes Made

- **Modified**: `wso2am-4.6.0/repository/resources/operation_policies/definitions/xmlValidator_v1.j2`
  - Changed hardcoded values to templated parameters using Jinja2 syntax
  - Parameters: `maxXMLDepth`, `maxElementCount`, `maxAttributeCount`, `maxAttributeLength`, `maxChildrenPerElement`, `entityExpansionLimit`, `dtdEnabled`, `externalEntitiesEnabled`, `requestMessageBufferSize`, `xmlSchemaValidator`

- **Modified**: `wso2am-4.6.0/repository/resources/operation_policies/specifications/xmlValidator_v1.json`
  - Added `policyAttributes` section with 10 configurable parameters
  - Each parameter includes validation regex, type, default value, and description
  - Parameters are displayed in the Publisher UI with user-friendly display names

## Build Information

- No build required - configuration changes only
- Modified policy template (.j2) and specification (.json) files
- Changes are loaded at runtime by WSO2 API Manager

## Artifacts Modified

- **Configuration Files**: Updated XML validator policy definition and specification files in `wso2am-4.6.0/repository/resources/operation_policies/`

## Testing

No testing required for configuration file changes per workflow guidelines.

## Modified wso2am Pack Download

The complete modified `wso2am-4.6.0` pack is available as a GitHub Actions artifact.

🔗 **[Download from GitHub Actions](https://github.com/ranuka-laksika/api-manager/actions/runs/19269845044)**

**Artifact Details:**
- **Name**: `wso2am-4.6.0-issue-69.zip`
- **How to Download**:
  1. Click the link above
  2. Scroll to "Artifacts" section
  3. Download the zip file
  4. Extract and use directly

**Contents**: Complete wso2am pack with updated XML validator policy template and specification files ready to use.

## Verification Steps

After deploying the updated pack:

1. Start WSO2 API Manager
2. Navigate to Publisher Portal
3. Create or edit an API
4. Go to API Resources → Select a resource → Add Policy → XML Validator
5. Verify that the policy now displays configurable parameters (Max XML Depth, Max Element Count, etc.)
6. Confirm that parameter values can be modified through the UI

## Benefits

- ✅ Users can now configure XML validation limits through Publisher UI
- ✅ No need to create custom policies for simple parameter changes
- ✅ Consistent user experience between JSON and XML validators
- ✅ Enhanced flexibility and usability